### PR TITLE
Clean up dependencies

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -2,17 +2,15 @@ PATH
   remote: .
   specs:
     konfipay (1.0.0)
+      activesupport
       camt_parser
       http
       json
-      sepa_king
       sidekiq
 
 GEM
   remote: https://rubygems.org/
   specs:
-    activemodel (6.1.4.1)
-      activesupport (= 6.1.4.1)
     activesupport (6.1.4.1)
       concurrent-ruby (~> 1.0, >= 1.0.2)
       i18n (>= 1.6, < 2)
@@ -46,9 +44,8 @@ GEM
     http-cookie (1.0.4)
       domain_name (~> 0.5)
     http-form_data (2.3.0)
-    i18n (1.8.10)
+    i18n (1.8.11)
       concurrent-ruby (~> 1.0)
-    iban-tools (1.1.0)
     json (2.6.1)
     llhttp-ffi (0.4.0)
       ffi-compiler (~> 1.0)
@@ -60,7 +57,7 @@ GEM
       mini_portile2 (~> 2.6.1)
       racc (~> 1.4)
     parallel (1.21.0)
-    parser (3.0.2.0)
+    parser (3.0.3.1)
       ast (~> 2.4.1)
     pry (0.14.1)
       coderay (~> 1.1)
@@ -71,7 +68,7 @@ GEM
     rainbow (3.0.0)
     rake (13.0.6)
     redis (4.5.1)
-    regexp_parser (2.1.1)
+    regexp_parser (2.2.0)
     rexml (3.2.5)
     rspec (3.10.0)
       rspec-core (~> 3.10.0)
@@ -85,8 +82,8 @@ GEM
     rspec-mocks (3.10.2)
       diff-lcs (>= 1.2.0, < 2.0)
       rspec-support (~> 3.10.0)
-    rspec-support (3.10.2)
-    rubocop (1.22.2)
+    rspec-support (3.10.3)
+    rubocop (1.23.0)
       parallel (~> 1.10)
       parser (>= 3.0.0.0)
       rainbow (>= 2.2.2, < 4.0)
@@ -95,19 +92,15 @@ GEM
       rubocop-ast (>= 1.12.0, < 2.0)
       ruby-progressbar (~> 1.7)
       unicode-display_width (>= 1.4.0, < 3.0)
-    rubocop-ast (1.12.0)
+    rubocop-ast (1.14.0)
       parser (>= 3.0.1.1)
-    rubocop-performance (1.11.5)
+    rubocop-performance (1.12.0)
       rubocop (>= 1.7.0, < 2.0)
       rubocop-ast (>= 0.4.0)
-    rubocop-rspec (2.5.0)
+    rubocop-rspec (2.6.0)
       rubocop (~> 1.19)
     ruby-progressbar (1.11.0)
-    sepa_king (0.12.0)
-      activemodel (>= 3.1)
-      iban-tools
-      nokogiri
-    sidekiq (6.2.2)
+    sidekiq (6.3.1)
       connection_pool (>= 2.2.2)
       rack (~> 2.0)
       redis (>= 4.2.0)

--- a/konfipay.gemspec
+++ b/konfipay.gemspec
@@ -36,9 +36,13 @@ Gem::Specification.new do |spec|
   spec.add_development_dependency 'rubocop-rspec'
   spec.add_development_dependency 'simplecov'
   spec.add_development_dependency 'webmock'
+  spec.add_dependency 'activesupport'
   spec.add_dependency 'camt_parser'
   spec.add_dependency 'http'
   spec.add_dependency 'json'
-  spec.add_dependency 'sepa_king'
+  # spec.add_dependency 'sepa_king'
   spec.add_dependency 'sidekiq'
+  spec.metadata = {
+    'rubygems_mfa_required' => 'true'
+  }
 end

--- a/lib/konfipay.rb
+++ b/lib/konfipay.rb
@@ -1,7 +1,9 @@
 # frozen_string_literal: true
 
+require 'active_support'
+require 'active_support/core_ext'
 require 'http'
-require 'sepa_king'
+# require 'sepa_king'
 require 'camt_parser'
 require 'sidekiq'
 


### PR DESCRIPTION
* Remove sepa_king from dependencies as it's currently not needed, and the dependency here clashes with the one in main project
* Add active support instead for convenience methods, it was previously pulled in by sepa_king
* bump all gems
* rubocop housekeeping