### PR TITLE
Automatic retry after auth failure

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: .
   specs:
-    konfipay (1.3.0)
+    konfipay (1.3.1)
       activesupport
       camt_parser
       http
@@ -43,7 +43,7 @@ GEM
     http-cookie (1.0.4)
       domain_name (~> 0.5)
     http-form_data (2.3.0)
-    i18n (1.9.1)
+    i18n (1.10.0)
       concurrent-ruby (~> 1.0)
     json (2.6.1)
     llhttp-ffi (0.4.0)
@@ -108,7 +108,7 @@ GEM
       simplecov-html (~> 0.11)
       simplecov_json_formatter (~> 0.1)
     simplecov-html (0.12.3)
-    simplecov_json_formatter (0.1.3)
+    simplecov_json_formatter (0.1.4)
     tzinfo (2.0.4)
       concurrent-ruby (~> 1.0)
     unf (0.1.4)

--- a/README.md
+++ b/README.md
@@ -49,6 +49,10 @@ end
 
 ## Usage
 
+Note: Unless otherwise noted, all API calls handle Authentication "under the hood" by requesting a token from the API if needed, and will
+retry this once on subsequent api calls with the same client instance (if operations take very long, it's possible that the token
+expires before the operation is finished, retrying authentication once allows everything to finish).
+
 ### Operations
 
 1) Fetch statements

--- a/README.md
+++ b/README.md
@@ -49,9 +49,8 @@ end
 
 ## Usage
 
-Note: Unless otherwise noted, all API calls handle Authentication "under the hood" by requesting a token from the API if needed, and will
-retry this once on subsequent api calls with the same client instance (if operations take very long, it's possible that the token
-expires before the operation is finished, retrying authentication once allows everything to finish).
+Note: API calls handle Authentication "under the hood" by requesting a token from the API if needed, and will reauthenticate once on subsequent API calls with the same client instance. If an operation takes long, it's possible that the token
+expires before the operation is finished. Retrying authentication once allows everything to finish.
 
 ### Operations
 

--- a/lib/konfipay/version.rb
+++ b/lib/konfipay/version.rb
@@ -1,5 +1,5 @@
 # frozen_string_literal: true
 
 module Konfipay
-  VERSION = '1.3.0'
+  VERSION = '1.3.1'
 end

--- a/spec/konfipay/client_spec.rb
+++ b/spec/konfipay/client_spec.rb
@@ -201,9 +201,7 @@ RSpec.describe Konfipay::Client do
                      headers: response_is_json)
       end
 
-      context 'without arguments' do
-        it_behaves_like 'success'
-      end
+      it_behaves_like 'success'
     end
 
     context 'when konfipay returns success' do
@@ -216,9 +214,7 @@ RSpec.describe Konfipay::Client do
                      headers: response_is_json)
       end
 
-      context 'without arguments' do
-        it_behaves_like 'success'
-      end
+      it_behaves_like 'success'
     end
   end
 

--- a/spec/konfipay/client_spec.rb
+++ b/spec/konfipay/client_spec.rb
@@ -36,6 +36,13 @@ RSpec.describe Konfipay::Client do
     { 'Content-Type' => 'text/xml; charset=UTF-8' }
   end
 
+  let(:response_is_auth_error) do
+    {
+      'Content-Type' => 'text/plain',
+      'Www-Authenticate' => 'You shall not pass.'
+    }
+  end
+
   def stub_login_token_api_call!
     stub_request(:post, 'https://portal.konfipay.de/api/v4/Auth/Login/Token')
       .with(
@@ -98,6 +105,21 @@ RSpec.describe Konfipay::Client do
       end
     end
 
+    context 'when konfipay returns 401 error' do
+      before do
+        stub_login_token_api_call!
+        stub_request(http_method, stubbed_url)
+          .with(headers: request_headers)
+          .to_return(status: 401,
+                     body: nil,
+                     headers: response_is_auth_error)
+      end
+
+      it 'raises Unauthorized error with mesage from header' do
+        expect { result }.to raise_error(Konfipay::Client::Unauthorized, 'You shall not pass.')
+      end
+    end
+
     context 'when konfipay returns 403 error' do
       before do
         stub_login_token_api_call!
@@ -148,18 +170,43 @@ RSpec.describe Konfipay::Client do
   end
 
   shared_examples_for 'documentItems response parsing' do
-    context 'when konfipay returns success' do
-      let(:expected_parsed_json) do
-        { 'documentItems' =>
-          [{ 'rId' => '5c19b66h-3d6e-4e8a-4548-622bd50a7af2',
-             'href' => 'api/v4.0/Document/Camt/5c19b66h-3d6e-4e8a-4548-622bd50a7af2',
-             'timestamp' => '2021-10-28T23:21:59+02:00',
-             'iban' => 'DE02300606010002474689',
-             'isNew' => true,
-             'format' => 'camt.053',
-             'fileName' => '2021-10-28_C53_DE02300606010002474689_EUR_365352.xml' }] }
+    let(:expected_parsed_json) do
+      { 'documentItems' =>
+        [{ 'rId' => '5c19b66h-3d6e-4e8a-4548-622bd50a7af2',
+           'href' => 'api/v4.0/Document/Camt/5c19b66h-3d6e-4e8a-4548-622bd50a7af2',
+           'timestamp' => '2021-10-28T23:21:59+02:00',
+           'iban' => 'DE02300606010002474689',
+           'isNew' => true,
+           'format' => 'camt.053',
+           'fileName' => '2021-10-28_C53_DE02300606010002474689_EUR_365352.xml' }] }
+    end
+
+    shared_examples_for 'success' do
+      it 'returns list of new documents' do
+        expect(result).to eq(expected_parsed_json)
+      end
+    end
+
+    context 'when konfipay returns first 401, then success' do
+      before do
+        stub_login_token_api_call!
+        stub_request(:get, stubbed_url)
+          .with(headers: request_headers)
+          .to_return(status: 401,
+                     body: nil,
+                     headers: response_is_auth_error)
+          .then
+          .to_return(status: 200,
+                     body: expected_parsed_json.to_json,
+                     headers: response_is_json)
       end
 
+      context 'without arguments' do
+        it_behaves_like 'success'
+      end
+    end
+
+    context 'when konfipay returns success' do
       before do
         stub_login_token_api_call!
         stub_request(:get, stubbed_url)
@@ -170,9 +217,7 @@ RSpec.describe Konfipay::Client do
       end
 
       context 'without arguments' do
-        it 'returns list of new documents' do
-          expect(result).to eq(expected_parsed_json)
-        end
+        it_behaves_like 'success'
       end
     end
   end
@@ -204,6 +249,29 @@ RSpec.describe Konfipay::Client do
 
     it_behaves_like 'api error handling', :get
 
+    shared_examples_for 'success' do
+      it 'returns a parsed camt file' do
+        expect(result).to be_an_instance_of(CamtParser::Format053::Base)
+      end
+    end
+
+    context 'when konfipay first returns 401, then success' do
+      before do
+        stub_login_token_api_call!
+        stub_request(:get, stubbed_url)
+          .with(headers: request_headers)
+          .to_return(status: 401,
+                     body: nil,
+                     headers: response_is_auth_error)
+          .then
+          .to_return(status: 200,
+                     body: camt_xml,
+                     headers: response_is_xml)
+      end
+
+      it_behaves_like 'success'
+    end
+
     context 'when konfipay returns success' do
       before do
         stub_login_token_api_call!
@@ -215,40 +283,58 @@ RSpec.describe Konfipay::Client do
       end
 
       context 'without arguments' do
-        it 'returns a parsed camt file' do
-          expect(result).to be_an_instance_of(CamtParser::Format053::Base)
-        end
+        it_behaves_like 'success'
       end
 
       context 'with mark_as_read = false' do
         let(:stubbed_url) { "https://portal.konfipay.de/api/v4/Document/Camt/#{r_id}?ack=false" }
         let(:result) { client.camt_file(r_id, false) }
 
-        it 'returns a parsed camt file' do
-          expect(result).to be_an_instance_of(CamtParser::Format053::Base)
-        end
+        it_behaves_like 'success'
       end
     end
   end
 
   describe 'acknowledge_camt_file' do
     let(:r_id) { 'a-b-c' }
+    let(:expected_parsed_json) do
+      { 'rId' => r_id,
+        'href' => "api/v4.0/Document/Camt/#{r_id}",
+        'timestamp' => '2021-10-28T23:21:59+02:00',
+        'iban' => 'DE02300606010002474689',
+        'isNew' => false,
+        'format' => 'camt.053',
+        'fileName' => '2021-10-28_C53_DE02300606010002474689_EUR_365352.xml' }
+    end
     let(:stubbed_url) { "https://portal.konfipay.de/api/v4/Document/Camt/#{r_id}/Acknowledge" }
     let(:result) { client.acknowledge_camt_file(r_id) }
 
     it_behaves_like 'api error handling', :post
 
-    context 'when konfipay returns success' do
-      let(:expected_parsed_json) do
-        { 'rId' => r_id,
-          'href' => "api/v4.0/Document/Camt/#{r_id}",
-          'timestamp' => '2021-10-28T23:21:59+02:00',
-          'iban' => 'DE02300606010002474689',
-          'isNew' => false,
-          'format' => 'camt.053',
-          'fileName' => '2021-10-28_C53_DE02300606010002474689_EUR_365352.xml' }
+    shared_examples_for 'success' do
+      it 'returns parsed response' do
+        expect(result).to eq(expected_parsed_json)
+      end
+    end
+
+    context 'when konfipay returns first 401, then success' do
+      before do
+        stub_login_token_api_call!
+        stub_request(:post, stubbed_url)
+          .with(headers: request_headers)
+          .to_return(status: 401,
+                     body: nil,
+                     headers: response_is_auth_error)
+          .then
+          .to_return(status: 200,
+                     body: expected_parsed_json.to_json,
+                     headers: response_is_json)
       end
 
+      it_behaves_like 'success'
+    end
+
+    context 'when konfipay returns success' do
       before do
         stub_login_token_api_call!
         stub_request(:post, stubbed_url)
@@ -258,9 +344,7 @@ RSpec.describe Konfipay::Client do
                      headers: response_is_json)
       end
 
-      it 'returns parsed response' do
-        expect(result).to eq(expected_parsed_json)
-      end
+      it_behaves_like 'success'
     end
   end
 end

--- a/spec/konfipay/client_spec.rb
+++ b/spec/konfipay/client_spec.rb
@@ -115,7 +115,7 @@ RSpec.describe Konfipay::Client do
                      headers: response_is_auth_error)
       end
 
-      it 'raises Unauthorized error with mesage from header' do
+      it 'raises Unauthorized error with message from header' do
         expect { result }.to raise_error(Konfipay::Client::Unauthorized, 'You shall not pass.')
       end
     end


### PR DESCRIPTION
Add feature that retries all api calls (except authentication) once if authentication fails.

This can happen when operations take a really long time to finish, and subsequent api calls then have an outdated token, for example when processing a huge camt file, then trying to ack it.