### PR TITLE
Return multi-doc transactions in useful order

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: .
   specs:
-    konfipay (1.3.1)
+    konfipay (1.3.2)
       activesupport
       camt_parser
       http

--- a/lib/konfipay/operations/fetch_statements.rb
+++ b/lib/konfipay/operations/fetch_statements.rb
@@ -50,7 +50,7 @@ module Konfipay
       #
       # In "history" mode, transactions between additionally needed "from" and "to" filter keys are returned,
       # they are not marked as read. "from" and "to" need to be strings in iso8601 format.
-      # 
+      #
       # Please note that from and to refer to the date of the camt53 file - this usually is provided a banking
       # day _after_ the contained transactions. I.e. if you want the transactions that were booked on
       # 2022-03-02 and 2022-03-03, filter by "from" => "2022-03-03" and "to" => "2022-03-04".

--- a/lib/konfipay/operations/fetch_statements.rb
+++ b/lib/konfipay/operations/fetch_statements.rb
@@ -50,6 +50,10 @@ module Konfipay
       #
       # In "history" mode, transactions between additionally needed "from" and "to" filter keys are returned,
       # they are not marked as read. "from" and "to" need to be strings in iso8601 format.
+      # 
+      # Please note that from and to refer to the date of the camt53 file - this usually is provided a banking
+      # day _after_ the contained transactions. I.e. if you want the transactions that were booked on
+      # 2022-03-02 and 2022-03-03, filter by "from" => "2022-03-03" and "to" => "2022-03-04".
       #
       # Returns transaction from all configured accounts by default.
       # Filter by using {'iban' => 'an account iban'} as filters argument.

--- a/lib/konfipay/version.rb
+++ b/lib/konfipay/version.rb
@@ -1,5 +1,5 @@
 # frozen_string_literal: true
 
 module Konfipay
-  VERSION = '1.3.1'
+  VERSION = '1.3.2'
 end

--- a/spec/konfipay/operations/fetch_statements_spec.rb
+++ b/spec/konfipay/operations/fetch_statements_spec.rb
@@ -17,26 +17,32 @@ RSpec.describe Konfipay::Operations::FetchStatements do
   let(:r_id2) { 'f-g-h' }
 
   let(:statements_parsed_json) do
-    { 'documentItems' =>
-      [{
-        'rId' => r_id1,
-        'href' => "api/v4.0/Document/Camt/#{r_id1}",
-        'timestamp' => '2022-01-05T23:21:59+02:00',
-        'iban' => iban,
-        'isNew' => true,
-        'format' => 'camt.053',
-        'fileName' => "2021-01-05_C53_#{iban}_EUR_365352.xml"
-      },
-
-       {
-         'rId' => r_id2,
-         'href' => "api/v4.0/Document/Camt/#{r_id2}",
-         'timestamp' => '2022-01-21T23:21:59+02:00',
-         'iban' => iban,
-         'isNew' => true,
-         'format' => 'camt.053',
-         'fileName' => "2022-01-21_C53_#{iban}_EUR_365352.xml"
-       }] }
+    {
+      'documentItems' =>
+      [
+        # This is the order in which the api returns docs - newest-first,
+        # which is not good for processing (bounces come before books) so
+        # we have to reverse this
+        {
+          'rId' => r_id2,
+          'href' => "api/v4.0/Document/Camt/#{r_id2}",
+          'timestamp' => '2022-01-21T23:21:59+02:00',
+          'iban' => iban,
+          'isNew' => true,
+          'format' => 'camt.053',
+          'fileName' => "2022-01-21_C53_#{iban}_EUR_365352.xml"
+        },
+        {
+          'rId' => r_id1,
+          'href' => "api/v4.0/Document/Camt/#{r_id1}",
+          'timestamp' => '2022-01-05T23:21:59+02:00',
+          'iban' => iban,
+          'isNew' => true,
+          'format' => 'camt.053',
+          'fileName' => "2021-01-05_C53_#{iban}_EUR_365352.xml"
+        }
+      ]
+    }
   end
 
   let(:parsed_camt_file1) do


### PR DESCRIPTION
Fix returned order of transactions - files come in from API newest-first, which results in bounces coming in possibly before books.

Reorder list of docs before retreiving them, add docs, add specs.