### PR TITLE
Quick and dirty hack to allow a second, "other" api key to be configu…

### DIFF
--- a/lib/konfipay.rb
+++ b/lib/konfipay.rb
@@ -121,7 +121,8 @@ module Konfipay
       callback_method,
       queue = nil,
       payment_data,
-      transaction_id
+      transaction_id,
+      use_other_api_key
     )
       # TODO: validate input, check that class and method are implemented
       queue ||= :default # TODO: This should be in configuration and not repeated here
@@ -130,7 +131,8 @@ module Konfipay
         callback_method,
         'credit_transfer',
         payment_data,
-        transaction_id
+        transaction_id,
+        use_other_api_key
       )
       true
     end
@@ -182,7 +184,8 @@ module Konfipay
         callback_method,
         'direct_debit',
         payment_data,
-        transaction_id
+        transaction_id,
+        false
       )
       true
     end

--- a/lib/konfipay/configuration.rb
+++ b/lib/konfipay/configuration.rb
@@ -5,6 +5,7 @@ module Konfipay
 
   class Configuration
     attr_accessor :api_key, # API key used to access Konfipay API. Can be configured in Konfipay Portal.
+                  :normal_api_key,
                   :other_api_key,
                   :logger, # Optional logger object - has to respond to debug, info, etc.
                   :timeout, # for http requests to API, 30s by default
@@ -18,6 +19,7 @@ module Konfipay
       @timeout = (10 * 60) # uploading large PAIN files can simply take a long time
       # TODO: Make a short timeout for GETs and a large one for the other http verbs?
       @base_url = BASE_URL
+      @normal_api_key = @api_key
       @api_client_name = 'Konfipay Ruby Client'
       @api_client_version = Konfipay::VERSION
       @transfer_monitoring_interval = 10 * 60

--- a/lib/konfipay/configuration.rb
+++ b/lib/konfipay/configuration.rb
@@ -5,6 +5,7 @@ module Konfipay
 
   class Configuration
     attr_accessor :api_key, # API key used to access Konfipay API. Can be configured in Konfipay Portal.
+                  :other_api_key,
                   :logger, # Optional logger object - has to respond to debug, info, etc.
                   :timeout, # for http requests to API, 30s by default
                   :base_url,
@@ -40,8 +41,8 @@ module Konfipay
     attr_writer :configuration
   end
 
-  def self.configuration
-    @configuration ||= Configuration.new
+  def self.configuration(*args)
+    @configuration ||= Configuration.new(*args)
   end
 
   def self.reset_configuration!

--- a/lib/konfipay/jobs/base.rb
+++ b/lib/konfipay/jobs/base.rb
@@ -17,14 +17,15 @@ module Konfipay
         callback_class.constantize.send(callback_method, data, transaction_id)
       end
 
-      def schedule_monitor(callback_class, callback_method, r_id, transaction_id)
+      def schedule_monitor(callback_class, callback_method, r_id, transaction_id, use_other_api_key)
         logger&.info "Scheduling job to monitor #{r_id} / #{transaction_id}"
         Konfipay::Jobs::MonitorTransfer.perform_in(
           @config.transfer_monitoring_interval,
           callback_class,
           callback_method,
           r_id,
-          transaction_id
+          transaction_id,
+          use_other_api_key
         )
       end
     end

--- a/lib/konfipay/jobs/initialize_transfer.rb
+++ b/lib/konfipay/jobs/initialize_transfer.rb
@@ -6,12 +6,13 @@ module Konfipay
       # Don't retry (could start multiple payments), but keep job in "dead" queue for debugging
       sidekiq_options retry: 0
 
-      def perform(callback_class, callback_method, mode, payment_data, transaction_id)
-        data = Konfipay::Operations::InitializeTransfer.new.submit(mode, payment_data, transaction_id)
+      def perform(callback_class, callback_method, mode, payment_data, transaction_id, use_other_api_key) # rubocop:disable Metrics/ParameterLists
+        data = Konfipay::Operations::InitializeTransfer.new.submit(mode, payment_data, transaction_id,
+                                                                   use_other_api_key)
         run_callback(callback_class, callback_method, data, transaction_id)
         return if data['final']
 
-        schedule_monitor(callback_class, callback_method, data['data']['rId'], transaction_id)
+        schedule_monitor(callback_class, callback_method, data['data']['rId'], transaction_id, use_other_api_key)
       end
     end
   end

--- a/lib/konfipay/jobs/monitor_transfer.rb
+++ b/lib/konfipay/jobs/monitor_transfer.rb
@@ -3,10 +3,10 @@
 module Konfipay
   module Jobs
     class MonitorTransfer < Konfipay::Jobs::Base
-      def perform(callback_class, callback_method, r_id, transaction_id)
-        data = Konfipay::Operations::TransferInfo.new.fetch(r_id)
+      def perform(callback_class, callback_method, r_id, transaction_id, use_other_api_key)
+        data = Konfipay::Operations::TransferInfo.new.fetch(r_id, use_other_api_key)
         run_callback(callback_class, callback_method, data, transaction_id)
-        schedule_monitor(callback_class, callback_method, r_id, transaction_id) unless data['final']
+        schedule_monitor(callback_class, callback_method, r_id, transaction_id, use_other_api_key) unless data['final']
       end
     end
   end

--- a/lib/konfipay/operations/initialize_transfer.rb
+++ b/lib/konfipay/operations/initialize_transfer.rb
@@ -52,7 +52,7 @@ module Konfipay
                   raise ArgumentError, "Unknown mode #{mode.inspect}"
                 end
         rescue ArgumentError => e
-          logger&.info "#{mode.inspect} failed to start, invalid payment_data"
+          logger&.error "#{mode.inspect} failed to start, invalid payment_data"
           return {
             'final' => true,
             'success' => false,
@@ -63,15 +63,16 @@ module Konfipay
         end
         data = nil
         if use_other_api_key
-          logger&.info 'using other api key'
+          logger&.warn 'using other api key'
           @config.api_key = @config.other_api_key
         else
-          logger&.info 'using normal api key'
+          logger&.warn 'using normal api key'
+          @config.api_key = @config.normal_api_key
         end
         begin
           data = @client.submit_pain_file(xml) # here comes the pain
         rescue Konfipay::Client::Unauthorized, Konfipay::Client::BadRequest => e
-          logger&.info "#{mode.inspect} failed to start"
+          logger&.error "#{mode.inspect} failed to start"
           return {
             'final' => true,
             'success' => false,

--- a/lib/konfipay/operations/initialize_transfer.rb
+++ b/lib/konfipay/operations/initialize_transfer.rb
@@ -35,7 +35,7 @@ module Konfipay
       # be returned by the Konfipay API.
       # "data" is verbatim what the Konfipay API returned for the initial process start.
       # Note that rId is needed to identify this transfer process on all subsequent (manual) API calls.
-      def submit(mode, payment_data, transaction_id)
+      def submit(mode, payment_data, transaction_id, use_other_api_key)
         raise ArgumentError, "Unknown mode #{mode.inspect}" unless %w[credit_transfer direct_debit].include?(mode)
 
         logger&.info "starting #{mode.inspect} transfer for #{transaction_id.inspect}"
@@ -62,6 +62,12 @@ module Konfipay
           }
         end
         data = nil
+        if use_other_api_key
+          logger&.info 'using other api key'
+          @config.api_key = @config.other_api_key
+        else
+          logger&.info 'using normal api key'
+        end
         begin
           data = @client.submit_pain_file(xml) # here comes the pain
         rescue Konfipay::Client::Unauthorized, Konfipay::Client::BadRequest => e

--- a/lib/konfipay/operations/transfer_info.rb
+++ b/lib/konfipay/operations/transfer_info.rb
@@ -12,17 +12,18 @@ module Konfipay
         logger&.info "Fetching info for r_id #{r_id.inspect}"
 
         if use_other_api_key
-          logger&.info 'using other api key'
+          logger&.warn 'using other api key'
           @config.api_key = @config.other_api_key
         else
-          logger&.info 'using normal api key'
+          logger&.warn 'using normal api key'
+          @config.api_key = @config.normal_api_key
         end
 
         data = nil
         begin
           data = @client.pain_file_info(r_id)
         rescue Konfipay::Client::Unauthorized, Konfipay::Client::BadRequest => e
-          logger&.info "Transfer info fetch for r_id #{r_id.inspect} finished with error"
+          logger&.error "Transfer info fetch for r_id #{r_id.inspect} finished with error"
           return {
             'final' => true,
             'success' => false,

--- a/lib/konfipay/operations/transfer_info.rb
+++ b/lib/konfipay/operations/transfer_info.rb
@@ -8,8 +8,15 @@ module Konfipay
       # Konfipay::Operations::InitializeTransfer#submit
       #
       # The r_id was returned after the first successful #submit call.
-      def fetch(r_id)
+      def fetch(r_id, use_other_api_key)
         logger&.info "Fetching info for r_id #{r_id.inspect}"
+
+        if use_other_api_key
+          logger&.info 'using other api key'
+          @config.api_key = @config.other_api_key
+        else
+          logger&.info 'using normal api key'
+        end
 
         data = nil
         begin

--- a/spec/konfipay/jobs/initialize_transfer_spec.rb
+++ b/spec/konfipay/jobs/initialize_transfer_spec.rb
@@ -10,7 +10,8 @@ RSpec.describe Konfipay::Jobs::InitializeTransfer do
         'example_callback_fetch_statements',
         'credit_transfer',
         payment_data,
-        transaction_id
+        transaction_id,
+        false
       )
     end
 
@@ -35,7 +36,8 @@ RSpec.describe Konfipay::Jobs::InitializeTransfer do
       allow(operation).to receive(:submit).with(
         'credit_transfer',
         payment_data,
-        transaction_id
+        transaction_id,
+        false
       ).and_return(data)
       allow(ExampleCallbackClass).to receive(:example_callback_fetch_statements)
       allow(Konfipay::Jobs::MonitorTransfer).to receive(:perform_in)
@@ -70,7 +72,8 @@ RSpec.describe Konfipay::Jobs::InitializeTransfer do
           'ExampleCallbackClass',
           'example_callback_fetch_statements',
           r_id,
-          transaction_id
+          transaction_id,
+          false
         )
       end
     end

--- a/spec/konfipay/jobs/monitor_transfer_spec.rb
+++ b/spec/konfipay/jobs/monitor_transfer_spec.rb
@@ -9,7 +9,8 @@ RSpec.describe Konfipay::Jobs::MonitorTransfer do
         'ExampleCallbackClass',
         'example_callback_fetch_statements',
         r_id,
-        transaction_id
+        transaction_id,
+        false
       )
     end
 
@@ -30,7 +31,7 @@ RSpec.describe Konfipay::Jobs::MonitorTransfer do
 
     before do
       allow(Konfipay::Operations::TransferInfo).to receive(:new).and_return(operation)
-      allow(operation).to receive(:fetch).with(r_id).and_return(data)
+      allow(operation).to receive(:fetch).with(r_id, false).and_return(data)
       allow(ExampleCallbackClass).to receive(:example_callback_fetch_statements)
       allow(described_class).to receive(:perform_in)
     end
@@ -64,7 +65,8 @@ RSpec.describe Konfipay::Jobs::MonitorTransfer do
           'ExampleCallbackClass',
           'example_callback_fetch_statements',
           r_id,
-          transaction_id
+          transaction_id,
+          false
         )
       end
     end

--- a/spec/konfipay/operations/initialize_transfer_spec.rb
+++ b/spec/konfipay/operations/initialize_transfer_spec.rb
@@ -95,7 +95,7 @@ RSpec.describe Konfipay::Operations::InitializeTransfer do
   context 'with a credit transfer' do
     it_behaves_like 'a pain submitter' do
       let(:submit_it) do
-        operation.submit('credit_transfer', payment_data, transaction_id)
+        operation.submit('credit_transfer', payment_data, transaction_id, false)
       end
       let(:payment_data) do
         { 'debtor' =>
@@ -137,7 +137,7 @@ RSpec.describe Konfipay::Operations::InitializeTransfer do
   context 'with a direct debit' do
     it_behaves_like 'a pain submitter' do
       let(:submit_it) do
-        operation.submit('direct_debit', payment_data, transaction_id)
+        operation.submit('direct_debit', payment_data, transaction_id, false)
       end
       let(:payment_data) do
         { 'creditor' =>

--- a/spec/konfipay/operations/transfer_info_spec.rb
+++ b/spec/konfipay/operations/transfer_info_spec.rb
@@ -30,7 +30,7 @@ RSpec.describe Konfipay::Operations::TransferInfo do
 
   describe 'fetch' do
     let(:fetch_it) do
-      operation.fetch(r_id)
+      operation.fetch(r_id, false)
     end
 
     it 'returns parsed data with success and final states' do

--- a/spec/konfipay_spec.rb
+++ b/spec/konfipay_spec.rb
@@ -143,7 +143,8 @@ RSpec.describe Konfipay do
       subject { start_transfer }
 
       let(:start_transfer) do
-        described_class.initialize_credit_transfer(callback_class, callback_method, queue, payment_data, transaction_id)
+        described_class.initialize_credit_transfer(callback_class, callback_method, queue, payment_data,
+                                                   transaction_id, false)
       end
 
       before do
@@ -163,7 +164,8 @@ RSpec.describe Konfipay do
             callback_method,
             'credit_transfer',
             payment_data,
-            transaction_id
+            transaction_id,
+            false
           )
         end
 
@@ -175,7 +177,8 @@ RSpec.describe Konfipay do
 
       context 'with default arguments' do
         let(:start_transfer) do
-          described_class.initialize_credit_transfer(callback_class, callback_method, nil, payment_data, transaction_id)
+          described_class.initialize_credit_transfer(callback_class, callback_method, nil, payment_data,
+                                                     transaction_id, false)
         end
 
         it 'uses the default queue' do
@@ -211,7 +214,8 @@ RSpec.describe Konfipay do
             callback_method,
             'direct_debit',
             payment_data,
-            transaction_id
+            transaction_id,
+            false
           )
         end
 


### PR DESCRIPTION
…red, and used on demand for specific credit transfer jobs (and the subsequent monitoring jobs).

This is only supposed to be used temporarily until we can refactor the whole arguments/options/configuration system...