### PR TITLE
Store payment data in Redis, not Sidekiq args

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: .
   specs:
-    konfipay (1.7.0)
+    konfipay (1.8.0)
       activesupport
       camt_parser
       http

--- a/README.md
+++ b/README.md
@@ -186,6 +186,7 @@ Konfipay.initialize_direct_debit(
 
 See the method's descriptions on details about the payment data format.
 
+Note that the payment_data is not passed into the Sidekiq jobs directly, as that might accidentally leak the data into logs etc. if there are issues - also systems like the Sidekiq dashboard do not handle large job arguments well. Instead this gem saves the data temporarily directly in Redis (using the same connection as Sidekiq). In case something goes very wrong, the keys have a TTL of 2 weeks so they data will not clog up Redis indefinitely.
 
 
 For developing features or hacking on this gem, note that all business logic is implemented in the "Operation" classes, which

--- a/lib/konfipay.rb
+++ b/lib/konfipay.rb
@@ -134,7 +134,7 @@ module Konfipay
         callback_class,
         callback_method,
         'credit_transfer',
-        payment_data,
+        store_payment_data_in_redis(payment_data, transaction_id),
         transaction_id,
         extract_config_options(api_key_name: api_key_name)
       )
@@ -185,7 +185,7 @@ module Konfipay
         callback_class,
         callback_method,
         'direct_debit',
-        payment_data,
+        store_payment_data_in_redis(payment_data, transaction_id),
         transaction_id,
         extract_config_options(api_key_name: api_key_name)
       )
@@ -197,6 +197,15 @@ module Konfipay
       # Make sure to be json-compatible and only pass on keys with values
       opts['api_key_name'] = api_key_name if api_key_name
       opts
+    end
+
+    def store_payment_data_in_redis(payment_data, transaction_id)
+      json = JSON.generate(payment_data)
+      key = "konfipay/data/#{transaction_id}"
+      Sidekiq.redis_pool.with do |conn|
+        conn.call("SET", key, json, ex: 2.weeks.to_i)
+      end
+      key
     end
   end
 end

--- a/lib/konfipay.rb
+++ b/lib/konfipay.rb
@@ -203,7 +203,7 @@ module Konfipay
       json = JSON.generate(payment_data)
       key = "konfipay/data/#{transaction_id}"
       Sidekiq.redis_pool.with do |conn|
-        conn.call("SET", key, json, ex: 2.weeks.to_i)
+        conn.call('SET', key, json, ex: 2.weeks.to_i)
       end
       key
     end

--- a/lib/konfipay/jobs/base.rb
+++ b/lib/konfipay/jobs/base.rb
@@ -31,9 +31,10 @@ module Konfipay
 
       def retrieve_payment_data_from_redis(key)
         json = Sidekiq.redis_pool.with do |conn|
-          conn.call("GETDEL", key)
+          conn.call('GETDEL', key)
         end
         raise "Could not get payment data from redis at #{key.inspect}!" if json.nil?
+
         JSON.parse(json)
       end
     end

--- a/lib/konfipay/jobs/base.rb
+++ b/lib/konfipay/jobs/base.rb
@@ -28,6 +28,14 @@ module Konfipay
           config_options
         )
       end
+
+      def retrieve_payment_data_from_redis(key)
+        json = Sidekiq.redis_pool.with do |conn|
+          conn.call("GETDEL", key)
+        end
+        raise "Could not get payment data from redis at #{key.inspect}!" if json.nil?
+        JSON.parse(json)
+      end
     end
   end
 end

--- a/lib/konfipay/jobs/initialize_transfer.rb
+++ b/lib/konfipay/jobs/initialize_transfer.rb
@@ -7,8 +7,9 @@ module Konfipay
       sidekiq_options retry: 0
 
       # rubocop:disable Metrics/ParameterLists
-      def perform(callback_class, callback_method, mode, payment_data, transaction_id, config_options = {})
+      def perform(callback_class, callback_method, mode, payment_data_key, transaction_id, config_options = {})
         @config = config_from_options(config_options)
+        payment_data = retrieve_payment_data_from_redis(payment_data_key)
         data = Konfipay::Operations::InitializeTransfer.new(@config).submit(mode, payment_data, transaction_id)
         run_callback(callback_class, callback_method, data, transaction_id)
         return if data['final']

--- a/lib/konfipay/version.rb
+++ b/lib/konfipay/version.rb
@@ -1,5 +1,5 @@
 # frozen_string_literal: true
 
 module Konfipay
-  VERSION = '1.7.0'
+  VERSION = '1.8.0'
 end

--- a/spec/konfipay/jobs/initialize_transfer_spec.rb
+++ b/spec/konfipay/jobs/initialize_transfer_spec.rb
@@ -48,7 +48,7 @@ RSpec.describe Konfipay::Jobs::InitializeTransfer do
 
     before do
       allow(Konfipay).to receive(:configuration).and_call_original
-      allow(sidekiq_redis_connection_dummy).to receive(:call).with('GETDEL', redis_key).and_return(payment_data_json)
+      allow(sidekiq_redis_connection_double).to receive(:call).with('GETDEL', redis_key).and_return(payment_data_json)
       allow(Konfipay::Operations::InitializeTransfer).to receive(:new).and_return(operation)
       allow(operation).to receive(:submit).with(
         'credit_transfer',
@@ -106,7 +106,7 @@ RSpec.describe Konfipay::Jobs::InitializeTransfer do
 
     context 'when payment_data is somehow missing' do
       it 'throws an exception' do
-        allow(sidekiq_redis_connection_dummy).to receive(:call).and_return(nil)
+        allow(sidekiq_redis_connection_double).to receive(:call).and_return(nil)
         expect { do_it }.to raise_error('Could not get payment data from redis at "konfipay/data/123xyz"!')
       end
     end

--- a/spec/konfipay/jobs/initialize_transfer_spec.rb
+++ b/spec/konfipay/jobs/initialize_transfer_spec.rb
@@ -22,7 +22,7 @@ RSpec.describe Konfipay::Jobs::InitializeTransfer do
         'ExampleCallbackClass',
         'example_callback_fetch_statements',
         'credit_transfer',
-        payment_data,
+        redis_key,
         transaction_id,
         { 'api_key_name' => 'other' }
       )
@@ -30,7 +30,9 @@ RSpec.describe Konfipay::Jobs::InitializeTransfer do
 
     let(:transaction_id) { '123xyz' }
     let(:r_id) { 'xxxxxxxxx' }
+    let(:redis_key) { 'konfipay/data/123xyz' }
     let(:payment_data) { { 'bla' => 'blub' } }
+    let(:payment_data_json) { '{"bla":"blub"}' }
     let(:final) { true }
     let(:data) do
       {
@@ -46,6 +48,7 @@ RSpec.describe Konfipay::Jobs::InitializeTransfer do
 
     before do
       allow(Konfipay).to receive(:configuration).and_call_original
+      allow(sidekiq_redis_connection_dummy).to receive(:call).with('GETDEL', redis_key).and_return(payment_data_json)
       allow(Konfipay::Operations::InitializeTransfer).to receive(:new).and_return(operation)
       allow(operation).to receive(:submit).with(
         'credit_transfer',
@@ -98,6 +101,13 @@ RSpec.describe Konfipay::Jobs::InitializeTransfer do
           transaction_id,
           { 'api_key_name' => 'other' }
         )
+      end
+    end
+
+    context 'when payment_data is somehow missing' do
+      it 'throws an exception' do
+        allow(sidekiq_redis_connection_dummy).to receive(:call).and_return(nil)
+        expect { do_it }.to raise_error('Could not get payment data from redis at "konfipay/data/123xyz"!')
       end
     end
   end

--- a/spec/konfipay_spec.rb
+++ b/spec/konfipay_spec.rb
@@ -22,7 +22,7 @@ RSpec.describe Konfipay do
     shared_examples_for 'a redis serializer' do
       it 'puts the serialized payment_data into Redis' do
         subject
-        expect(sidekiq_redis_connection_dummy).to have_received(:call).with(*redis_params)
+        expect(sidekiq_redis_connection_double).to have_received(:call).with(*redis_params)
       end
     end
 
@@ -189,7 +189,7 @@ RSpec.describe Konfipay do
       end
 
       before do
-        allow(sidekiq_redis_connection_dummy).to receive(:call)
+        allow(sidekiq_redis_connection_double).to receive(:call)
         allow(sidekiq_options_dummy).to receive(:perform_async)
         allow(Konfipay::Jobs::InitializeTransfer).to receive(:set).and_return(sidekiq_options_dummy)
       end
@@ -255,7 +255,7 @@ RSpec.describe Konfipay do
       end
 
       before do
-        allow(sidekiq_redis_connection_dummy).to receive(:call)
+        allow(sidekiq_redis_connection_double).to receive(:call)
         allow(sidekiq_options_dummy).to receive(:perform_async)
         allow(Konfipay::Jobs::InitializeTransfer).to receive(:set).and_return(sidekiq_options_dummy)
       end

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -8,6 +8,9 @@ require 'konfipay'
 require 'webmock/rspec'
 require 'active_support/testing/time_helpers'
 
+require 'sidekiq/testing'
+Sidekiq::Testing.fake!
+
 require 'support/example_callback_class'
 
 RSpec.configure do |config|
@@ -20,6 +23,19 @@ RSpec.configure do |config|
   config.expect_with :rspec do |c|
     c.syntax = :expect
   end
+
+  config.before do
+    @sidekiq_redis_pool_dummy = Class.new.new
+    @sidekiq_redis_connection_dummy = Class.new.new
+    allow(Sidekiq).to receive(:redis_pool).and_return(@sidekiq_redis_pool_dummy)
+    allow(@sidekiq_redis_pool_dummy).to receive(:with).and_yield(@sidekiq_redis_connection_dummy)
+  end
+
+  # rubocop:disable Style/TrivialAccessors
+  def sidekiq_redis_connection_dummy
+    @sidekiq_redis_connection_dummy
+  end
+  # rubocop:enable Style/TrivialAccessors
 
   config.include ActiveSupport::Testing::TimeHelpers
 end

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -25,15 +25,19 @@ RSpec.configure do |config|
   end
 
   config.before do
-    @sidekiq_redis_pool_dummy = Class.new.new
-    @sidekiq_redis_connection_dummy = Class.new.new
-    allow(Sidekiq).to receive(:redis_pool).and_return(@sidekiq_redis_pool_dummy)
-    allow(@sidekiq_redis_pool_dummy).to receive(:with).and_yield(@sidekiq_redis_connection_dummy)
+    stub_sidekiq_redis_connection_double
+  end
+
+  def stub_sidekiq_redis_connection_double
+    @sidekiq_redis_pool_double = instance_double(ConnectionPool)
+    allow(Sidekiq).to receive(:redis_pool).and_return(@sidekiq_redis_pool_double)
+    @sidekiq_redis_connection_double = instance_double(Sidekiq::RedisClientAdapter::CompatClient)
+    allow(@sidekiq_redis_pool_double).to receive(:with).and_yield(@sidekiq_redis_connection_double)
   end
 
   # rubocop:disable Style/TrivialAccessors
-  def sidekiq_redis_connection_dummy
-    @sidekiq_redis_connection_dummy
+  def sidekiq_redis_connection_double
+    @sidekiq_redis_connection_double
   end
   # rubocop:enable Style/TrivialAccessors
 


### PR DESCRIPTION
We encountered some problems with pushing (large) payment data directly in the Sidekiq job args:
* While Sidekiq itself handles these fine, the sidekiq web interface loads the job args and can use up a lot of web server memory
* It can be a confidentiality problem that payment info is visible in the same web interface
* Similarly, if there are errors, Sidekiq could log the payment info into logging systems etc.

Instead, store the data directly in Redis and just pass the key to it through Sidekiq. Add a TTL to the key so that in case the Job gets lost, the data does not stay in Redis indefinitely.