### PR TITLE
Refactor configuration system

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: .
   specs:
-    konfipay (1.5.2)
+    konfipay (1.6.0)
       activesupport
       camt_parser
       http

--- a/lib/konfipay/configuration.rb
+++ b/lib/konfipay/configuration.rb
@@ -1,25 +1,23 @@
 # frozen_string_literal: true
 
 module Konfipay
-  BASE_URL = 'https://portal.konfipay.de'
-
   class Configuration
+    BASE_URL_DEFAULT = 'https://portal.konfipay.de'
+    TIMEOUT_DEFAULT = (10 * 60) # uploading large PAIN files can simply take a long time
+    API_CLIENT_NAME_DEFAULT = 'Konfipay Ruby Client'
+    API_CLIENT_VERSION_DEFAULT = Konfipay::VERSION
+    TRANSFER_MONITORING_INTERVAL_DEFAULT = (10 * 60)
+
     attr_accessor :api_key, # API key used to access Konfipay API. Can be configured in Konfipay Portal.
                   :logger, # Optional logger object - has to respond to debug, info, etc.
-                  :timeout, # for http requests to API, 30s by default
+                  :timeout, # for http requests to API, in seconds
                   :base_url,
                   :api_client_name, # sent to konfipay with each http request as a papertrail
                   :api_client_version, # ditto
-                  # in seconds, 10 minutes by default - how often to check for updates on a payment process
-                  :transfer_monitoring_interval
+                  :transfer_monitoring_interval # how often to check for updates on a payment process, in seconds
 
-    def initialize
-      @timeout = (10 * 60) # uploading large PAIN files can simply take a long time
-      # TODO: Make a short timeout for GETs and a large one for the other http verbs?
-      @base_url = BASE_URL
-      @api_client_name = 'Konfipay Ruby Client'
-      @api_client_version = Konfipay::VERSION
-      @transfer_monitoring_interval = 10 * 60
+    class << self
+      attr_accessor :initializer_block
     end
 
     def check!
@@ -31,26 +29,60 @@ module Konfipay
 
       %i[timeout transfer_monitoring_interval].each do |number_in_seconds|
         value = send(number_in_seconds)
-        raise ArgumentError, "#{value.inspect} has to be a positive integer" if value.to_i <= 0
+        if value.to_i <= 0
+          raise ArgumentError,
+                "#{number_in_seconds} has to be a positive integer, not #{value.inspect}"
+        end
       end
+
+      self
     end
+
+    def apply_gem_defaults!
+      @timeout = TIMEOUT_DEFAULT
+      @base_url = BASE_URL_DEFAULT
+      @api_client_name = API_CLIENT_NAME_DEFAULT
+      @api_client_version = API_CLIENT_VERSION_DEFAULT
+      @transfer_monitoring_interval = TRANSFER_MONITORING_INTERVAL_DEFAULT
+      self
+    end
+
+    def apply_initializer!(initializer_block)
+      initializer_block&.call(self)
+      self
+    end
+
+    # rubocop:disable Metrics/ParameterLists
+    def apply_runtime_options!(api_key: nil, logger: nil, timeout: nil, base_url: nil, api_client_name: nil,
+                               api_client_version: nil, transfer_monitoring_interval: nil)
+      @api_key = api_key if api_key
+      @logger = logger if logger
+      @timeout = timeout if timeout
+      @base_url = base_url if base_url
+      @api_client_name = api_client_name if api_client_name
+      @api_client_version = api_client_version if api_client_version
+      @transfer_monitoring_interval = transfer_monitoring_interval if transfer_monitoring_interval
+      self
+    end
+    # rubocop:enable Metrics/ParameterLists
   end
 
-  class << self
-    attr_writer :configuration
+  def self.configure(&block)
+    Konfipay::Configuration.initializer_block = block
+    nil
   end
 
-  def self.configuration
-    @configuration ||= Configuration.new
-  end
-
-  def self.reset_configuration!
-    @configuration = nil
-  end
-
-  def self.configure
-    yield(configuration)
-    configuration.check!
-    configuration
+  # The main way to get to configuration - this will initialize a new Konfipay::Configuration instance
+  # when called and applies gem defaults, initializer defaults (from Konfipay.configure) and last
+  # passed-in options - see Konfipay::Configuration#apply_runtime_options! for the possible parameters
+  #
+  # A simple sanity check on values is also performed.
+  def self.configuration(**kwargs)
+    Konfipay::Configuration.new.tap do |config|
+      config.apply_gem_defaults!
+      config.apply_initializer!(Konfipay::Configuration.initializer_block)
+      config.apply_runtime_options!(**kwargs)
+      config.check!
+    end
   end
 end

--- a/lib/konfipay/jobs/fetch_statements.rb
+++ b/lib/konfipay/jobs/fetch_statements.rb
@@ -4,7 +4,7 @@ module Konfipay
   module Jobs
     class FetchStatements < Konfipay::Jobs::Base
       def perform(callback_class, callback_method, mode, filters = {}, options = {})
-        Konfipay::Operations::FetchStatements.new.fetch(mode, filters, options) do |data|
+        Konfipay::Operations::FetchStatements.new(@config).fetch(mode, filters, options) do |data|
           run_callback(callback_class, callback_method, data)
         end
       end

--- a/lib/konfipay/jobs/initialize_transfer.rb
+++ b/lib/konfipay/jobs/initialize_transfer.rb
@@ -7,7 +7,7 @@ module Konfipay
       sidekiq_options retry: 0
 
       def perform(callback_class, callback_method, mode, payment_data, transaction_id)
-        data = Konfipay::Operations::InitializeTransfer.new.submit(mode, payment_data, transaction_id)
+        data = Konfipay::Operations::InitializeTransfer.new(@config).submit(mode, payment_data, transaction_id)
         run_callback(callback_class, callback_method, data, transaction_id)
         return if data['final']
 

--- a/lib/konfipay/jobs/monitor_transfer.rb
+++ b/lib/konfipay/jobs/monitor_transfer.rb
@@ -4,7 +4,7 @@ module Konfipay
   module Jobs
     class MonitorTransfer < Konfipay::Jobs::Base
       def perform(callback_class, callback_method, r_id, transaction_id)
-        data = Konfipay::Operations::TransferInfo.new.fetch(r_id)
+        data = Konfipay::Operations::TransferInfo.new(@config).fetch(r_id)
         run_callback(callback_class, callback_method, data, transaction_id)
         schedule_monitor(callback_class, callback_method, r_id, transaction_id) unless data['final']
       end

--- a/lib/konfipay/version.rb
+++ b/lib/konfipay/version.rb
@@ -1,5 +1,5 @@
 # frozen_string_literal: true
 
 module Konfipay
-  VERSION = '1.5.2'
+  VERSION = '1.6.0'
 end

--- a/spec/konfipay/client_spec.rb
+++ b/spec/konfipay/client_spec.rb
@@ -10,6 +10,7 @@ RSpec.describe Konfipay::Client do
       # Uncomment this for debug output from http gem during specs
       # c.logger = Logger.new($stdout)
     end
+    Konfipay.configuration
   end
 
   let(:client) do

--- a/spec/konfipay/jobs/fetch_statements_spec.rb
+++ b/spec/konfipay/jobs/fetch_statements_spec.rb
@@ -5,7 +5,7 @@ require 'spec_helper'
 RSpec.describe Konfipay::Jobs::FetchStatements do
   describe 'perform' do
     let(:do_it) do
-      described_class.new.perform(
+      described_class.new(config).perform(
         'ExampleCallbackClass',
         'example_callback_fetch_statements',
         'new',
@@ -15,7 +15,8 @@ RSpec.describe Konfipay::Jobs::FetchStatements do
     end
 
     let(:data) { 'le_data' }
-    let(:operation) { Konfipay::Operations::FetchStatements.new }
+    let(:config) { Konfipay.configuration(api_key: '<key>') }
+    let(:operation) { Konfipay::Operations::FetchStatements.new(config) }
 
     before do
       allow(Konfipay::Operations::FetchStatements).to receive(:new).and_return(operation)

--- a/spec/konfipay/jobs/initialize_transfer_spec.rb
+++ b/spec/konfipay/jobs/initialize_transfer_spec.rb
@@ -5,7 +5,7 @@ require 'spec_helper'
 RSpec.describe Konfipay::Jobs::InitializeTransfer do
   describe 'perform' do
     let(:do_it) do
-      described_class.new.perform(
+      described_class.new(config).perform(
         'ExampleCallbackClass',
         'example_callback_fetch_statements',
         'credit_transfer',
@@ -28,7 +28,8 @@ RSpec.describe Konfipay::Jobs::InitializeTransfer do
         }
       }
     end
-    let(:operation) { Konfipay::Operations::InitializeTransfer.new }
+    let(:config) { Konfipay.configuration(api_key: '<key>') }
+    let(:operation) { Konfipay::Operations::InitializeTransfer.new(config) }
 
     before do
       allow(Konfipay::Operations::InitializeTransfer).to receive(:new).and_return(operation)

--- a/spec/konfipay/jobs/monitor_transfer_spec.rb
+++ b/spec/konfipay/jobs/monitor_transfer_spec.rb
@@ -5,7 +5,7 @@ require 'spec_helper'
 RSpec.describe Konfipay::Jobs::MonitorTransfer do
   describe 'perform' do
     let(:do_it) do
-      described_class.new.perform(
+      described_class.new(config).perform(
         'ExampleCallbackClass',
         'example_callback_fetch_statements',
         r_id,
@@ -26,7 +26,8 @@ RSpec.describe Konfipay::Jobs::MonitorTransfer do
         }
       }
     end
-    let(:operation) { Konfipay::Operations::TransferInfo.new }
+    let(:config) { Konfipay.configuration(api_key: '<key>') }
+    let(:operation) { Konfipay::Operations::TransferInfo.new(config) }
 
     before do
       allow(Konfipay::Operations::TransferInfo).to receive(:new).and_return(operation)

--- a/spec/konfipay/operations/fetch_statements_spec.rb
+++ b/spec/konfipay/operations/fetch_statements_spec.rb
@@ -7,7 +7,7 @@ require 'spec_helper'
 # rubocop:disable RSpec/MultipleExpectations
 # rubocop:disable RSpec/IndexedLet
 RSpec.describe Konfipay::Operations::FetchStatements do
-  let(:config) { Konfipay.configuration }
+  let(:config) { Konfipay.configuration(api_key: '<key>') }
   let(:client) do
     Konfipay::Client.new(config)
   end

--- a/spec/konfipay/operations/initialize_transfer_spec.rb
+++ b/spec/konfipay/operations/initialize_transfer_spec.rb
@@ -7,7 +7,7 @@ require 'spec_helper'
 # rubocop:disable RSpec/MultipleExpectations
 RSpec.describe Konfipay::Operations::InitializeTransfer do
   shared_examples_for 'a pain submitter' do
-    let(:config) { Konfipay.configuration }
+    let(:config) { Konfipay.configuration(api_key: '<key>') }
     let(:client) do
       Konfipay::Client.new(config)
     end

--- a/spec/konfipay/operations/transfer_info_spec.rb
+++ b/spec/konfipay/operations/transfer_info_spec.rb
@@ -6,7 +6,7 @@ require 'spec_helper'
 # rubocop:disable RSpec/StubbedMock
 # rubocop:disable RSpec/MultipleExpectations
 RSpec.describe Konfipay::Operations::TransferInfo do
-  let(:config) { Konfipay.configuration }
+  let(:config) { Konfipay.configuration(api_key: '<key>') }
   let(:client) do
     Konfipay::Client.new(config)
   end

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -22,8 +22,4 @@ RSpec.configure do |config|
   end
 
   config.include ActiveSupport::Testing::TimeHelpers
-
-  config.after do
-    Konfipay.reset_configuration!
-  end
 end


### PR DESCRIPTION
The main goal here is to avoid having the configuration being cached on a class level, which has caused subtle bugs in the past. Also, this provides a clear three-level config approach - gem defaults, static configuration via the usual initializer block, and finally runtime overrides.

This is a stepping stone to make it possible to have multiple api keys configured and switching between them for each task, which can then replace the hack in https://github.com/MeinGrundeinkommen/konfipay/tree/multiple-api-keys-feature