### PR TITLE
Fix parsing issue with camt53 entries with missing amount details

### DIFF
--- a/lib/konfipay/camt_digester.rb
+++ b/lib/konfipay/camt_digester.rb
@@ -52,8 +52,8 @@ module Konfipay
     def debit_hash(transaction)
       # Have to crowbar in, the gem allows no access :/
       xml = transaction.instance_variable_get(:@xml_data)
-
-      transaction_amount = parse_cents(xml.xpath('AmtDtls/TxAmt/Amt').text)
+      amount = (xml.xpath('AmtDtls/TxAmt/Amt').text.presence || xml.xpath('Amt').text.presence)
+      transaction_amount = parse_cents(amount)
       original_amount = parse_cents(xml.xpath('AmtDtls/InstdAmt/Amt').text)
 
       {

--- a/spec/examples/camt053/mixed_examples_02.xml
+++ b/spec/examples/camt053/mixed_examples_02.xml
@@ -551,6 +551,116 @@
         </NtryDtls>
         <AddtlNtryInf>Storno</AddtlNtryInf>
       </Ntry>
+      <Ntry>
+        <Amt Ccy="EUR">6.00</Amt>
+        <CdtDbtInd>DBIT</CdtDbtInd>
+        <Sts>
+          <Cd>BOOK</Cd>
+        </Sts>
+        <BookgDt>
+          <Dt>2024-12-05</Dt>
+        </BookgDt>
+        <ValDt>
+          <Dt>2024-12-05</Dt>
+        </ValDt>
+        <AcctSvcrRef>2024120512350854000</AcctSvcrRef>
+        <BkTxCd>
+          <Domn>
+            <Cd>PMNT</Cd>
+            <Fmly>
+              <Cd>IDDT</Cd>
+              <SubFmlyCd>UPDD</SubFmlyCd>
+            </Fmly>
+          </Domn>
+          <Prtry>
+            <Cd>NRTI+109+00931</Cd>
+            <Issr>DK</Issr>
+          </Prtry>
+        </BkTxCd>
+        <NtryDtls>
+          <TxDtls>
+            <Refs>
+              <EndToEndId>Mandat22-04.12.2024</EndToEndId>
+              <TxId>2024120379966115090100000010007649</TxId>
+              <MndtId>Mandat22</MndtId>
+            </Refs>
+            <Amt Ccy="EUR">6.00</Amt>
+            <CdtDbtInd>DBIT</CdtDbtInd>
+            <BkTxCd>
+              <Domn>
+                <Cd>PMNT</Cd>
+                <Fmly>
+                  <Cd>IDDT</Cd>
+                  <SubFmlyCd>UPDD</SubFmlyCd>
+                </Fmly>
+              </Domn>
+              <Prtry>
+                <Cd>NRTI+109+00931</Cd>
+                <Issr>DK</Issr>
+              </Prtry>
+            </BkTxCd>
+            <RltdPties>
+              <Dbtr>
+                <Pty>
+                  <Nm>Throatwobbler Mangrove</Nm>
+                </Pty>
+              </Dbtr>
+              <DbtrAcct>
+                <Id>
+                  <IBAN>LT121000011101001000</IBAN>
+                </Id>
+              </DbtrAcct>
+              <Cdtr>
+                <Pty>
+                  <Nm>Unsere Organisation</Nm>
+                </Pty>
+              </Cdtr>
+              <CdtrAcct>
+                <Id>
+                  <IBAN>DE02300606010002474689</IBAN>
+                </Id>
+              </CdtrAcct>
+            </RltdPties>
+            <RltdAgts>
+              <DbtrAgt>
+                <FinInstnId>
+                  <BICFI>BANKABCXXX</BICFI>
+                </FinInstnId>
+              </DbtrAgt>
+            </RltdAgts>
+            <RmtInf>
+              <Ustrd>Erhaltene Rueckweisung von Bank wg. AM04 Deckung ungenügend SVWZ: REJECT, Mandat22: Spende EREF: Mandat22-04.12.2024 IBAN: LT121000011101001000 BIC: BANKABCXXX</Ustrd>
+            </RmtInf>
+            <RtrInf>
+              <OrgnlBkTxCd>
+                <Domn>
+                  <Cd>PMNT</Cd>
+                  <Fmly>
+                    <Cd>IDDT</Cd>
+                    <SubFmlyCd>UPDD</SubFmlyCd>
+                  </Fmly>
+                </Domn>
+                <Prtry>
+                  <Cd>171</Cd>
+                  <Issr>DK</Issr>
+                </Prtry>
+              </OrgnlBkTxCd>
+              <Orgtr>
+                <Id>
+                  <OrgId>
+                    <AnyBIC>OURBIC123</AnyBIC>
+                  </OrgId>
+                </Id>
+              </Orgtr>
+              <Rsn>
+                <Cd>AM04</Cd>
+              </Rsn>
+              <AddtlInf>Deckung ungenügend</AddtlInf>
+            </RtrInf>
+          </TxDtls>
+        </NtryDtls>
+        <AddtlNtryInf>Retourenbelastung</AddtlNtryInf>
+      </Ntry>
     </Stmt>
   </BkToCstmrStmt>
 </Document>

--- a/spec/examples/camt053/mixed_examples_08.xml
+++ b/spec/examples/camt053/mixed_examples_08.xml
@@ -553,6 +553,116 @@
         </NtryDtls>
         <AddtlNtryInf>Storno</AddtlNtryInf>
       </Ntry>
+      <Ntry>
+        <Amt Ccy="EUR">6.00</Amt>
+        <CdtDbtInd>DBIT</CdtDbtInd>
+        <Sts>
+          <Cd>BOOK</Cd>
+        </Sts>
+        <BookgDt>
+          <Dt>2024-12-05</Dt>
+        </BookgDt>
+        <ValDt>
+          <Dt>2024-12-05</Dt>
+        </ValDt>
+        <AcctSvcrRef>2024120512350854000</AcctSvcrRef>
+        <BkTxCd>
+          <Domn>
+            <Cd>PMNT</Cd>
+            <Fmly>
+              <Cd>IDDT</Cd>
+              <SubFmlyCd>UPDD</SubFmlyCd>
+            </Fmly>
+          </Domn>
+          <Prtry>
+            <Cd>NRTI+109+00931</Cd>
+            <Issr>DK</Issr>
+          </Prtry>
+        </BkTxCd>
+        <NtryDtls>
+          <TxDtls>
+            <Refs>
+              <EndToEndId>Mandat22-04.12.2024</EndToEndId>
+              <TxId>2024120379966115090100000010007649</TxId>
+              <MndtId>Mandat22</MndtId>
+            </Refs>
+            <Amt Ccy="EUR">6.00</Amt>
+            <CdtDbtInd>DBIT</CdtDbtInd>
+            <BkTxCd>
+              <Domn>
+                <Cd>PMNT</Cd>
+                <Fmly>
+                  <Cd>IDDT</Cd>
+                  <SubFmlyCd>UPDD</SubFmlyCd>
+                </Fmly>
+              </Domn>
+              <Prtry>
+                <Cd>NRTI+109+00931</Cd>
+                <Issr>DK</Issr>
+              </Prtry>
+            </BkTxCd>
+            <RltdPties>
+              <Dbtr>
+                <Pty>
+                  <Nm>Throatwobbler Mangrove</Nm>
+                </Pty>
+              </Dbtr>
+              <DbtrAcct>
+                <Id>
+                  <IBAN>LT121000011101001000</IBAN>
+                </Id>
+              </DbtrAcct>
+              <Cdtr>
+                <Pty>
+                  <Nm>Unsere Organisation</Nm>
+                </Pty>
+              </Cdtr>
+              <CdtrAcct>
+                <Id>
+                  <IBAN>DE02300606010002474689</IBAN>
+                </Id>
+              </CdtrAcct>
+            </RltdPties>
+            <RltdAgts>
+              <DbtrAgt>
+                <FinInstnId>
+                  <BICFI>BANKABCXXX</BICFI>
+                </FinInstnId>
+              </DbtrAgt>
+            </RltdAgts>
+            <RmtInf>
+              <Ustrd>Erhaltene Rueckweisung von Bank wg. AM04 Deckung ungenügend SVWZ: REJECT, Mandat22: Spende EREF: Mandat22-04.12.2024 IBAN: LT121000011101001000 BIC: BANKABCXXX</Ustrd>
+            </RmtInf>
+            <RtrInf>
+              <OrgnlBkTxCd>
+                <Domn>
+                  <Cd>PMNT</Cd>
+                  <Fmly>
+                    <Cd>IDDT</Cd>
+                    <SubFmlyCd>UPDD</SubFmlyCd>
+                  </Fmly>
+                </Domn>
+                <Prtry>
+                  <Cd>171</Cd>
+                  <Issr>DK</Issr>
+                </Prtry>
+              </OrgnlBkTxCd>
+              <Orgtr>
+                <Id>
+                  <OrgId>
+                    <AnyBIC>OURBIC123</AnyBIC>
+                  </OrgId>
+                </Id>
+              </Orgtr>
+              <Rsn>
+                <Cd>AM04</Cd>
+              </Rsn>
+              <AddtlInf>Deckung ungenügend</AddtlInf>
+            </RtrInf>
+          </TxDtls>
+        </NtryDtls>
+        <AddtlNtryInf>Retourenbelastung</AddtlNtryInf>
+      </Ntry>
     </Stmt>
   </BkToCstmrStmt>
 </Document>

--- a/spec/konfipay/operations/fetch_statements_spec.rb
+++ b/spec/konfipay/operations/fetch_statements_spec.rb
@@ -151,6 +151,21 @@ RSpec.describe Konfipay::Operations::FetchStatements do
         'original_amount_in_cents' => nil,
         'fees' => nil,
         'return_information' => nil
+      },
+      {
+        'amount_in_cents' => 600,
+        'currency' => 'EUR',
+        'end_to_end_reference' => 'Mandat22-04.12.2024',
+        'executed_on' => '2024-12-05',
+        'fees' => nil,
+        'iban' => 'DE02300606010002474689',
+        'name' => 'Unsere Organisation',
+        'original_amount_in_cents' => nil,
+        'remittance_information' =>
+         'Erhaltene Rueckweisung von Bank wg. AM04 Deckung ungenügend SVWZ: REJECT, Mandat22: Spende EREF: Mandat22-04.12.2024 IBAN: LT121000011101001000 BIC: BANKABCXXX',
+        'return_information' => 'Deckung ungenügend',
+        'type' => 'debit',
+        'additional_information' => 'Retourenbelastung'
       }
     ]
   end


### PR DESCRIPTION
Recently we've come across a small number of SEPA returns in camt53 files for which the `<AmtDtls>` element ist missing, only an `<Amt>` being present. Strange but we should be able to parse them so add a fallback xpath, and specs.

For posterity: We've processed millions of transactions and always the amount was represented like this:
```
            <AmtDtls>
              <TxAmt>
                <Amt Ccy="EUR">13.50</Amt>
              </TxAmt>
            </AmtDtls>
```
Since recently, a small number of transactions, only for immediately returned/canceled debits (without fees), this whole block is missing, and only this was present:
```
            <Amt Ccy="EUR">6.00</Amt>
```