### PR TITLE
Disable GH actions updates again

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -14,9 +14,10 @@ updates:
     - "MGPalmer"
     - "0000magda0000"
   open-pull-requests-limit: 10
-- package-ecosystem: github-actions
-  directory: "/"
-  schedule:
-    interval: weekly
-  cooldown:
-    default-days: 14
+# Disabled until we have actual actions in .github/workflows
+# - package-ecosystem: github-actions
+#   directory: "/"
+#   schedule:
+#     interval: weekly
+#   cooldown:
+#     default-days: 14


### PR DESCRIPTION
...dependabot reports errors as there are no actual actions (yet): https://github.com/MeinGrundeinkommen/konfipay/network/updates/35722296/jobs